### PR TITLE
added support for 12-bit ADC resolution on Arduino Due

### DIFF
--- a/EmonLib.cpp
+++ b/EmonLib.cpp
@@ -2,6 +2,8 @@
   Emon.cpp - Library for openenergymonitor
   Created by Trystan Lea, April 27 2010
   GNU GPL
+  modified to use up to 12 bits ADC resolution (ex. Arduino Due)
+  by boredman@boredomprojects.net 26.12.2013
 */
 
 //#include "WProgram.h" un-comment for use on older versions of Arduino IDE
@@ -78,7 +80,7 @@ void EnergyMonitor::calcVI(int crossings, int timeout)
   while(st==false)                                   //the while loop...
   {
      startV = analogRead(inPinV);                    //using the voltage waveform
-     if ((startV < 550) && (startV > 440)) st=true;  //check its within range
+     if ((startV < (ADC_COUNTS/2+50)) && (startV > (ADC_COUNTS/2-50))) st=true;  //check its within range
      if ((millis()-start)>timeout) st = true;
   }
   
@@ -151,10 +153,10 @@ void EnergyMonitor::calcVI(int crossings, int timeout)
   //Calculation of the root of the mean of the voltage and current squared (rms)
   //Calibration coeficients applied. 
   
-  double V_RATIO = VCAL *((SUPPLYVOLTAGE/1000.0) / 1023.0);
+  double V_RATIO = VCAL *((SUPPLYVOLTAGE/1000.0) / (ADC_COUNTS));
   Vrms = V_RATIO * sqrt(sumV / numberOfSamples); 
   
-  double I_RATIO = ICAL *((SUPPLYVOLTAGE/1000.0) / 1023.0);
+  double I_RATIO = ICAL *((SUPPLYVOLTAGE/1000.0) / (ADC_COUNTS));
   Irms = I_RATIO * sqrt(sumI / numberOfSamples); 
 
   //Calculation power values
@@ -194,7 +196,7 @@ double EnergyMonitor::calcIrms(int NUMBER_OF_SAMPLES)
     sumI += sqI;
   }
 
-  double I_RATIO = ICAL *((SUPPLYVOLTAGE/1000.0) / 1023.0);
+  double I_RATIO = ICAL *((SUPPLYVOLTAGE/1000.0) / (ADC_COUNTS));
   Irms = I_RATIO * sqrt(sumI / NUMBER_OF_SAMPLES); 
 
   //Reset accumulators

--- a/EmonLib.h
+++ b/EmonLib.h
@@ -2,6 +2,8 @@
   Emon.h - Library for openenergymonitor
   Created by Trystan Lea, April 27 2010
   GNU GPL
+  modified to use up to 12 bits ADC resolution (ex. Arduino Due)
+  by boredman@boredomprojects.net 26.12.2013
 */
 
 #ifndef EmonLib_h
@@ -16,6 +18,19 @@
 #include "WProgram.h"
 
 #endif
+
+// to enable 12-bit ADC resolution on Arduino Due, 
+// include the following line in main sketch inside setup() function:
+//  analogReadResolution(ADC_BITS);
+// otherwise will default to 10 bits, as in regular Arduino-based boards.
+#if defined(__arm__)
+#define ADC_BITS    12
+#else
+#define ADC_BITS    10
+#endif
+
+#define ADC_COUNTS  (1<<ADC_BITS)
+
 
 class EnergyMonitor
 {


### PR DESCRIPTION
To enable this feature on Arduino Due, add the following statement to setup() function in main sketch:
analogReadResolution(ADC_BITS);

Note: ADC_BITS is automatically defined in EmonLib.h as 12 on ARM-based Due or as 10 on any other AVR-based board.
