### PR TITLE
added 3-phase buffer-delay algorithm, when CT sensors connected to different line phases.

### DIFF
--- a/EmonLib_3PH.h
+++ b/EmonLib_3PH.h
@@ -2,10 +2,13 @@
   Emon.h - Library for openenergymonitor
   Created by Trystan Lea, April 27 2010
   GNU GPL
+  modified to use up to 12 bits ADC resolution (ex. Arduino Due)
+  also includes 3-phase buffer-delay algorithm for monitoring different line phases with single AC-AC voltage adapter.
+  by boredman@boredomprojects.net 26.12.2013
 */
 
-#ifndef EmonLib_h
-#define EmonLib_h
+#ifndef EmonLib_3PH_h
+#define EmonLib_3PH_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
 
@@ -17,14 +20,31 @@
 
 #endif
 
+// to enable 12-bit ADC resolution on Arduino Due, 
+// include the following line in main sketch inside setup() function:
+//  analogReadResolution(ADC_BITS);
+// otherwise will default to 10 bits, as in regular Arduino-based boards.
+#if defined(__arm__)
+#define ADC_BITS    12
+#else
+#define ADC_BITS    10
+#endif
+
+#define ADC_COUNTS  (1<<ADC_BITS)
+
+
+#define PHASE2 65     //  Number of samples delay for L2
+#define PHASE3 130    //  Number  of samples delay for L3, also size of array
+                      //  These can be adjusted if the phase correction is not adequate
+
 class EnergyMonitor
 {
   public:
 
-    void voltage(int _inPinV, double _VCAL, double _PHASECAL);
+    void voltage(int _inPinV, double _VCAL, double _PHASECAL, int _PHASE);
     void current(int _inPinI, double _ICAL);
 
-    void voltageTX(double _VCAL, double _PHASECAL);
+    void voltageTX(double _VCAL, double _PHASECAL, int _PHASE);
     void currentTX(int _channel, double _ICAL);
 
     void calcVI(int crossings, int timeout);
@@ -49,6 +69,7 @@ class EnergyMonitor
     double VCAL;
     double ICAL;
     double PHASECAL;
+    int PHASE;
 
     //--------------------------------------------------------------------------------------
     // Variable declaration for emon_calc procedure
@@ -64,9 +85,6 @@ class EnergyMonitor
 	double sqV,sumV,sqI,sumI,instP,sumP;              //sq = squared, sum = Sum, inst = instantaneous
 
 	int startV;                                       //Instantaneous voltage at start of sample window.
-
-	boolean lastVCross, checkVCross;                  //Used to measure number of times threshold is crossed.
-	int crossCount;                                   // ''
 
 
 };

--- a/examples/ArduinoDue_3phase/ArduinoDue_3phase.ino
+++ b/examples/ArduinoDue_3phase/ArduinoDue_3phase.ino
@@ -1,0 +1,97 @@
+// Example of using Arduino Due as EmonTx box.
+// There are 10 CT inputs connected to various household lines (after circuit breakers)
+// and 1 AC-AC voltage adapter connected to one of these lines, used to measure voltage.
+// 10 lines are connected to different phases, thus, an extra parameter in voltage() function
+// used to indicate a particular phase number. The line with voltage adapter must be phase 1.
+
+#include <EmonLib_3PH.h>
+
+
+//==========================================================
+#define NSENSORS 10
+
+// Instance of EmonTX sensors
+EnergyMonitor emon[NSENSORS];
+
+// for each sensor we will print out real power and power factor
+typedef struct {
+  float realPower;    // 4
+  float powerFactor;  // 4
+} sEmonSensor;
+
+// Instance of measurement data structure
+sEmonSensor EmonTx[NSENSORS];
+//==========================================================
+
+
+
+void setup() {
+  Serial.begin(57600);
+  
+// Arduino Due can have up to 12 bits of ADC resolution
+  analogReadResolution(ADC_BITS);
+
+//---------------------------------------------------------------------
+// CALIBRATION
+// Note: AC-AC voltage adapter must always be connected to phase 1
+//---------------------------------------------------------------------
+  // Stove: brown (phase 2)
+  emon[0].voltage(11, 334.0, 2.0, 2);   // Voltage: pin, calib, phasecal, line phase.
+  emon[0].current(0, 97.7);             // Current: pin, calib.
+  // Stove: grey (phase 3)
+  emon[1].voltage(11, 334.0, 3.0, 3);   // Voltage: pin, calib, phasecal, line phase.
+  emon[1].current(1, 96.2);             // Current: pin, calib.
+  // Stove: black (phase 1)
+  emon[2].voltage(11, 334.0, 1.7, 1);   // Voltage: pin, calib, phasecal, line phase.
+  emon[2].current(2, 95.8);             // Current: pin, calib.
+  // Dishwasher (phase 2)
+  emon[3].voltage(11, 334.0, 2.0, 2);   // Voltage: pin, calib, phasecal, line phase.
+  emon[3].current(3, 95.9);             // Current: pin, calib.
+  // Kitchen (phase 3)
+  emon[4].voltage(11, 334.0, 3.0, 3);   // Voltage: pin, calib, phasecal, line phase.
+  emon[4].current(4, 97.7);             // Current: pin, calib.
+  // Living room (phase 1)
+  emon[5].voltage(11, 334.0, 1.7, 1);   // Voltage: pin, calib, phasecal, line phase.
+  emon[5].current(5, 95.9);             // Current: pin, calib.
+  // Common (phase 2)
+  emon[6].voltage(11, 334.0, 2.0, 2);   // Voltage: pin, calib, phasecal, line phase.
+  emon[6].current(6, 96.4);             // Current: pin, calib.
+  // Bath-Toilet (phase 3)
+  emon[7].voltage(11, 334.0, 3.0, 3);   // Voltage: pin, calib, phasecal, line phase.
+  emon[7].current(7, 96.3);             // Current: pin, calib.
+  // Washmachine (phase 1)
+  emon[8].voltage(11, 334.0, 1.7, 1);   // Voltage: pin, calib, phasecal, line phase.
+  emon[8].current(8, 96.4);             // Current: pin, calib.
+  // Floor light (phase 1)
+  emon[9].voltage(11, 334.0, 1.7, 1);   // Voltage: pin, calib, phasecal, line phase.
+  emon[9].current(9, 95.7);             // Current: pin, calib.
+}
+
+
+
+void loop() {
+
+  for (int i=0; i<NSENSORS; i++)
+  {
+    // perform measurements
+    emon[i].calcVI(16,2000);    // 2 h.c. for buffering + 14 h.c. for measuring
+    
+    // convert and pack data
+    EmonTx[i].realPower = (float)emon[i].realPower;
+    EmonTx[i].powerFactor = (float)emon[i].powerFactor;
+  }
+  
+  // Voltage sensor is connected to Washmachine line
+  float Voltage = (float)emon[8].Vrms;
+
+  // Printing out
+  Serial.print("Voltage: "); Serial.println(Voltage);
+  for(int i=0; i<NSENSORS; i++)
+  {
+    Serial.print(i); Serial.print(": ");
+    Serial.print("  RP=");
+    Serial.print(EmonTx[i].realPower);
+    Serial.print("  PF=");
+    Serial.println(EmonTx[i].powerFactor);
+  }
+}


### PR DESCRIPTION
- added 3-phase buffer-delay algorithm, when CT sensors connected to different line phases.
- also includes support for 12-bit ADC resolution on Arduino Due.

Since it makes sense to keep main EmonLib library single phase, these files were renamed to "EmonLib_3PH.cpp" and "EmonLib_3PH.h" 

Includes example sketch "ArduinoDue_3phase.ino" showing how to use Due as EmonTx box:
- There are 10 CT inputs connected to various household lines (after circuit breakers) and 1 AC-AC voltage adapter connected to one of these lines, used to measure voltage.
- 10 lines are connected to different phases, therefore, an extra parameter was added to functions voltage() and voltageTX() indicating a particular phase number. 
- The AC-AC line voltage adapter must be connected to phase 1.
