### PR TITLE
Externalize readVcc calibration constant

### DIFF
--- a/EmonLib.cpp
+++ b/EmonLib.cpp
@@ -248,7 +248,7 @@ long EnergyMonitor::readVcc() {
   while (bit_is_set(ADCSRA,ADSC));
   result = ADCL;
   result |= ADCH<<8;
-  result = 1126400L / result;                     //1100mV*1024 ADC steps http://openenergymonitor.org/emon/node/1186
+  result = READVCC_CALIBRATION_CONST / result;  //1100mV*1024 ADC steps http://openenergymonitor.org/emon/node/1186
   return result;
  #elif defined(__arm__)
   return (3300);                                  //Arduino Due

--- a/EmonLib.h
+++ b/EmonLib.h
@@ -19,6 +19,15 @@
 
 #endif
 
+// define theoretical vref calibration constant for use in readvcc()
+// 1100mV*1024 ADC steps http://openenergymonitor.org/emon/node/1186
+// override in your code with value for your specific AVR chip
+// determined by procedure described under "Calibrating the internal reference voltage" at
+// http://openenergymonitor.org/emon/buildingblocks/calibration
+#ifndef READVCC_CALIBRATION_CONST
+#define READVCC_CALIBRATION_CONST 1126400L
+#endif
+
 // to enable 12-bit ADC resolution on Arduino Due, 
 // include the following line in main sketch inside setup() function:
 //  analogReadResolution(ADC_BITS);


### PR DESCRIPTION
Allow user code to override the hard-coded reference voltage calibration constant in function EnergyMonitor::readVcc without them needing to modify EmonLib directly. Per "Calibrating the internal reference voltage" at http://openenergymonitor.org/emon/buildingblocks/calibration. 

To use, define your calculated calibration constant in your program *prior* to importing EmonLib.h. Existing programs will continue to work unchanged, since EmonLib.h will define default value if constant is not already defined. 

Example:
#define READVCC_CALIBRATION_CONST 1113108L    // calculated for a specific Arduino board, update this if using code on a different board
#include "EmonLib.h"


