### PR TITLE
RW: Replaced the high-pass filter with a low-pass and subtract

### DIFF
--- a/EmonLib.cpp
+++ b/EmonLib.cpp
@@ -4,35 +4,34 @@
   GNU GPL
   modified to use up to 12 bits ADC resolution (ex. Arduino Due)
   by boredman@boredomprojects.net 26.12.2013
+  Low Pass filter for offset removal replaces HP filter 1/1/2015 - RW
 */
 
 //#include "WProgram.h" un-comment for use on older versions of Arduino IDE
 #include "EmonLib.h"
 
 #if defined(ARDUINO) && ARDUINO >= 100
-
 #include "Arduino.h"
-
 #else
-
 #include "WProgram.h"
-
 #endif
+
 
 //--------------------------------------------------------------------------------------
 // Sets the pins to be used for voltage and current sensors
 //--------------------------------------------------------------------------------------
-void EnergyMonitor::voltage(int _inPinV, double _VCAL, double _PHASECAL)
+void EnergyMonitor::voltage(unsigned int _inPinV, double _VCAL, double _PHASECAL)
 {
    inPinV = _inPinV;
    VCAL = _VCAL;
    PHASECAL = _PHASECAL;
-}
+} 
 
-void EnergyMonitor::current(int _inPinI, double _ICAL)
+void EnergyMonitor::current(unsigned int _inPinI, double _ICAL)
 {
    inPinI = _inPinI;
    ICAL = _ICAL;
+   offsetI = ADC_COUNTS>>1;
 }
 
 //--------------------------------------------------------------------------------------
@@ -43,35 +42,37 @@ void EnergyMonitor::voltageTX(double _VCAL, double _PHASECAL)
    inPinV = 2;
    VCAL = _VCAL;
    PHASECAL = _PHASECAL;
+   offsetV = ADC_COUNTS>>1;
 }
 
-void EnergyMonitor::currentTX(int _channel, double _ICAL)
+void EnergyMonitor::currentTX(unsigned int _channel, double _ICAL)
 {
    if (_channel == 1) inPinI = 3;
    if (_channel == 2) inPinI = 0;
    if (_channel == 3) inPinI = 1;
    ICAL = _ICAL;
+   offsetI = ADC_COUNTS>>1;
 }
 
 //--------------------------------------------------------------------------------------
 // emon_calc procedure
-// Calculates realPower,apparentPower,powerFactor,Vrms,Irms,kwh increment
+// Calculates realPower,apparentPower,powerFactor,Vrms,Irms,kWh increment
 // From a sample window of the mains AC voltage and current.
 // The Sample window length is defined by the number of half wavelengths or crossings we choose to measure.
 //--------------------------------------------------------------------------------------
-void EnergyMonitor::calcVI(int crossings, int timeout)
+void EnergyMonitor::calcVI(unsigned int crossings, unsigned int timeout)
 {
    #if defined emonTxV3
-	int SUPPLYVOLTAGE=3300;
+	int SupplyVoltage=3300;
    #else 
-	int SUPPLYVOLTAGE = readVcc();
+	int SupplyVoltage = readVcc();
    #endif
 
-  int crossCount = 0;                             //Used to measure number of times threshold is crossed.
-  int numberOfSamples = 0;                        //This is now incremented  
+  unsigned int crossCount = 0;                             //Used to measure number of times threshold is crossed.
+  unsigned int numberOfSamples = 0;                        //This is now incremented  
 
   //-------------------------------------------------------------------------------------------------------------------------
-  // 1) Waits for the waveform to be close to 'zero' (500 adc) part in sin curve.
+  // 1) Waits for the waveform to be close to 'zero' (mid-scale adc) part in sin curve.
   //-------------------------------------------------------------------------------------------------------------------------
   boolean st=false;                                  //an indicator to exit the while loop
 
@@ -80,24 +81,19 @@ void EnergyMonitor::calcVI(int crossings, int timeout)
   while(st==false)                                   //the while loop...
   {
      startV = analogRead(inPinV);                    //using the voltage waveform
-     if ((startV < (ADC_COUNTS/2+50)) && (startV > (ADC_COUNTS/2-50))) st=true;  //check its within range
+     if ((startV < (ADC_COUNTS*0.55)) && (startV > (ADC_COUNTS*0.45))) st=true;  //check its within range
      if ((millis()-start)>timeout) st = true;
   }
   
   //-------------------------------------------------------------------------------------------------------------------------
-  // 2) Main measurment loop
+  // 2) Main measurement loop
   //------------------------------------------------------------------------------------------------------------------------- 
   start = millis(); 
 
   while ((crossCount < crossings) && ((millis()-start)<timeout)) 
   {
-    numberOfSamples++;                            //Count number of times looped.
-
-    lastSampleV=sampleV;                          //Used for digital high pass filter
-    lastSampleI=sampleI;                          //Used for digital high pass filter
-    
-    lastFilteredV = filteredV;                    //Used for offset removal
-    lastFilteredI = filteredI;                    //Used for offset removal   
+    numberOfSamples++;                       //Count number of times looped.
+    lastFilteredV = filteredV;               //Used for delay/phase compensation
     
     //-----------------------------------------------------------------------------
     // A) Read in raw voltage and current samples
@@ -106,10 +102,13 @@ void EnergyMonitor::calcVI(int crossings, int timeout)
     sampleI = analogRead(inPinI);                 //Read in raw current signal
 
     //-----------------------------------------------------------------------------
-    // B) Apply digital high pass filters to remove 2.5V DC offset (centered on 0V).
+    // B) Apply digital low pass filters to extract the 2.5 V or 1.65 V dc offset,
+    //     then subtract this - signal is now centred on 0 counts.
     //-----------------------------------------------------------------------------
-    filteredV = 0.996*(lastFilteredV+(sampleV-lastSampleV));
-    filteredI = 0.996*(lastFilteredI+(sampleI-lastSampleI));
+    offsetV = offsetV + ((sampleV-offsetV)/1024);
+	filteredV = sampleV - offsetV;
+    offsetI = offsetI + ((sampleI-offsetI)/1024);
+	filteredI = sampleI - offsetI;
    
     //-----------------------------------------------------------------------------
     // C) Root-mean-square method voltage
@@ -151,12 +150,12 @@ void EnergyMonitor::calcVI(int crossings, int timeout)
   // 3) Post loop calculations
   //------------------------------------------------------------------------------------------------------------------------- 
   //Calculation of the root of the mean of the voltage and current squared (rms)
-  //Calibration coeficients applied. 
+  //Calibration coefficients applied. 
   
-  double V_RATIO = VCAL *((SUPPLYVOLTAGE/1000.0) / (ADC_COUNTS));
+  double V_RATIO = VCAL *((SupplyVoltage/1000.0) / (ADC_COUNTS));
   Vrms = V_RATIO * sqrt(sumV / numberOfSamples); 
   
-  double I_RATIO = ICAL *((SUPPLYVOLTAGE/1000.0) / (ADC_COUNTS));
+  double I_RATIO = ICAL *((SupplyVoltage/1000.0) / (ADC_COUNTS));
   Irms = I_RATIO * sqrt(sumI / numberOfSamples); 
 
   //Calculation power values
@@ -172,22 +171,24 @@ void EnergyMonitor::calcVI(int crossings, int timeout)
 }
 
 //--------------------------------------------------------------------------------------
-double EnergyMonitor::calcIrms(int NUMBER_OF_SAMPLES)
+double EnergyMonitor::calcIrms(unsigned int Number_of_Samples)
 {
   
    #if defined emonTxV3
-	int SUPPLYVOLTAGE=3300;
+	int SupplyVoltage=3300;
    #else 
-	int SUPPLYVOLTAGE = readVcc();
+	int SupplyVoltage = readVcc();
    #endif
 
   
-  for (int n = 0; n < NUMBER_OF_SAMPLES; n++)
+  for (unsigned int n = 0; n < Number_of_Samples; n++)
   {
-    lastSampleI = sampleI;
     sampleI = analogRead(inPinI);
-    lastFilteredI = filteredI;
-    filteredI = 0.996*(lastFilteredI+sampleI-lastSampleI);
+
+    // Digital low pass filter extracts the 2.5 V or 1.65 V dc offset, 
+	//  then subtract this - signal is now centered on 0 counts.
+    offsetI = (offsetI + (sampleI-offsetI)/1024);
+	filteredI = sampleI - offsetI;
 
     // Root-mean-square method current
     // 1) square current values
@@ -196,8 +197,8 @@ double EnergyMonitor::calcIrms(int NUMBER_OF_SAMPLES)
     sumI += sqI;
   }
 
-  double I_RATIO = ICAL *((SUPPLYVOLTAGE/1000.0) / (ADC_COUNTS));
-  Irms = I_RATIO * sqrt(sumI / NUMBER_OF_SAMPLES); 
+  double I_RATIO = ICAL *((SupplyVoltage/1000.0) / (ADC_COUNTS));
+  Irms = I_RATIO * sqrt(sumI / Number_of_Samples); 
 
   //Reset accumulators
   sumI = 0;

--- a/EmonLib.cpp
+++ b/EmonLib.cpp
@@ -25,7 +25,8 @@ void EnergyMonitor::voltage(unsigned int _inPinV, double _VCAL, double _PHASECAL
    inPinV = _inPinV;
    VCAL = _VCAL;
    PHASECAL = _PHASECAL;
-} 
+   offsetV = ADC_COUNTS>>1;
+}
 
 void EnergyMonitor::current(unsigned int _inPinI, double _ICAL)
 {

--- a/EmonLib.h
+++ b/EmonLib.h
@@ -4,6 +4,7 @@
   GNU GPL
   modified to use up to 12 bits ADC resolution (ex. Arduino Due)
   by boredman@boredomprojects.net 26.12.2013
+  Low Pass filter for offset removal replaces HP filter 1/1/2015 - RW
 */
 
 #ifndef EmonLib_h
@@ -45,14 +46,14 @@ class EnergyMonitor
 {
   public:
 
-    void voltage(int _inPinV, double _VCAL, double _PHASECAL);
-    void current(int _inPinI, double _ICAL);
+    void voltage(unsigned int _inPinV, double _VCAL, double _PHASECAL);
+    void current(unsigned int _inPinI, double _ICAL);
 
     void voltageTX(double _VCAL, double _PHASECAL);
-    void currentTX(int _channel, double _ICAL);
+    void currentTX(unsigned int _channel, double _ICAL);
 
-    void calcVI(int crossings, int timeout);
-    double calcIrms(int NUMBER_OF_SAMPLES);
+    void calcVI(unsigned int crossings, unsigned int timeout);
+    double calcIrms(unsigned int NUMBER_OF_SAMPLES);
     void serialprint();
 
     long readVcc();
@@ -66,8 +67,8 @@ class EnergyMonitor
   private:
 
     //Set Voltage and current input pins
-    int inPinV;
-    int inPinI;
+    unsigned int inPinV;
+    unsigned int inPinI;
     //Calibration coeficients
     //These need to be set in order to obtain accurate results
     double VCAL;
@@ -77,11 +78,13 @@ class EnergyMonitor
     //--------------------------------------------------------------------------------------
     // Variable declaration for emon_calc procedure
     //--------------------------------------------------------------------------------------
-	int lastSampleV,sampleV;   //sample_ holds the raw analog read value, lastSample_ holds the last sample
-	int lastSampleI,sampleI;                      
+	int sampleV;  							 //sample_ holds the raw analog read value
+	int sampleI;                     
 
-	double lastFilteredV,filteredV;                   //Filtered_ is the raw analog value minus the DC offset
-	double lastFilteredI, filteredI;                  
+	double lastFilteredV,filteredV;          //Filtered_ is the raw analog value minus the DC offset
+	double filteredI;                  
+	double offsetV;                          //Low-pass filter output
+	double offsetI;                          //Low-pass filter output               
 
 	double phaseShiftedV;                             //Holds the calibrated phase shifted voltage.
 
@@ -90,7 +93,6 @@ class EnergyMonitor
 	int startV;                                       //Instantaneous voltage at start of sample window.
 
 	boolean lastVCross, checkVCross;                  //Used to measure number of times threshold is crossed.
-	int crossCount;                                   // ''
 
 
 };

--- a/EmonLib.h
+++ b/EmonLib.h
@@ -69,7 +69,7 @@ class EnergyMonitor
     //Set Voltage and current input pins
     unsigned int inPinV;
     unsigned int inPinI;
-    //Calibration coeficients
+    //Calibration coefficients
     //These need to be set in order to obtain accurate results
     double VCAL;
     double ICAL;


### PR DESCRIPTION
RW: low-pass filter to derive the offset and then subtract that from the input signal. Because the offset (hopefully) approximates to a steady direct voltage, initialising the filter is trivial. 

I've replaced the high-pass filter with a low-pass and subtract, and I've tidied up the signed values that don't need to be signed (not that it matters - it still doesn't trigger a compiler warning if you get it wrong!). I've also replaced the mid-point + 50 and mid-point - 50 for deciding the zero-crossing point with ADC_COUNTS*0.55 and ADC_COUNTS*0.45 in order to maintain the proportion with a 12-bit ADC.

Test results: The measured values are reported correctly the first time calcVI or calcIrms is called. It is tolerant (showing no discernible effect) of changes in the offset voltage to well beyond the normal component tolerances. It however still takes many calls of the method for the filter to stabilise when the CT is unplugged and the input is grounded and then the plug is restored - this is expected and inevitable, and that's partly due to the fact that I've taken advantage of the preloaded value and reduced the filter's α so as to reduce the ripple, which should improve the small-signal performance.