### PR TITLE
ADC readings fix

### DIFF
--- a/EmonLib.cpp
+++ b/EmonLib.cpp
@@ -82,7 +82,7 @@ void EnergyMonitor::calcVI(unsigned int crossings, unsigned int timeout)
   while(st==false)                                   //the while loop...
   {
      startV = analogRead(inPinV);                    //using the voltage waveform
-     if ((startV < (ADC_COUNTS*0.55)) && (startV > (ADC_COUNTS*0.45))) st=true;  //check its within range
+     if ((startV < (ADC_MAX_VALUE*0.55)) && (startV > (ADC_MAX_VALUE*0.45))) st=true;  //check its within range
      if ((millis()-start)>timeout) st = true;
   }
   
@@ -153,10 +153,10 @@ void EnergyMonitor::calcVI(unsigned int crossings, unsigned int timeout)
   //Calculation of the root of the mean of the voltage and current squared (rms)
   //Calibration coefficients applied. 
   
-  double V_RATIO = VCAL *((SupplyVoltage/1000.0) / (ADC_COUNTS));
+  double V_RATIO = VCAL * ((SupplyVoltage/1000.0) / (ADC_MAX_VALUE));
   Vrms = V_RATIO * sqrt(sumV / numberOfSamples); 
   
-  double I_RATIO = ICAL *((SupplyVoltage/1000.0) / (ADC_COUNTS));
+  double I_RATIO = ICAL * ((SupplyVoltage/1000.0) / (ADC_MAX_VALUE));
   Irms = I_RATIO * sqrt(sumI / numberOfSamples); 
 
   //Calculation power values
@@ -198,7 +198,7 @@ double EnergyMonitor::calcIrms(unsigned int Number_of_Samples)
     sumI += sqI;
   }
 
-  double I_RATIO = ICAL *((SupplyVoltage/1000.0) / (ADC_COUNTS));
+  double I_RATIO = ICAL * ((SupplyVoltage/1000.0) / (ADC_MAX_VALUE));
   Irms = I_RATIO * sqrt(sumI / Number_of_Samples); 
 
   //Reset accumulators

--- a/EmonLib.h
+++ b/EmonLib.h
@@ -40,7 +40,7 @@
 #endif
 
 #define ADC_COUNTS  (1<<ADC_BITS)
-
+#define ADC_MAX_VALUE  (ADC_COUNTS-1)
 
 class EnergyMonitor
 {


### PR DESCRIPTION
Hello,
please review the change proposal. Looks like it would be better to use 1023 instead of 1024 when converting ADC readings to voltage as far as 1023 is the maximum readings value.

For example, https://www.arduino.cc/en/Tutorial/ReadAnalogVoltage : 

`
float voltage= sensorValue * (5.0 / 1023.0);
`
