### PR TITLE
ATmega644/644P/1284/1284P support

### DIFF
--- a/library.json
+++ b/library.json
@@ -13,5 +13,5 @@
     "atmelavr",
     "atmelsam"
   ]
-  "version": 1.0
+  "version": "1.0"
 }

--- a/library.json
+++ b/library.json
@@ -2,6 +2,7 @@
   "name": "EmonLib",
   "keywords": "electricity, energy, monitoring",
   "description": "Energy Monitoring Library",
+  "version": "1.0",
   "repository":
   {
     "type": "git",
@@ -13,5 +14,4 @@
     "atmelavr",
     "atmelsam"
   ]
-  "version": "1.0"
 }

--- a/library.json
+++ b/library.json
@@ -8,9 +8,10 @@
     "url": "https://github.com/openenergymonitor/EmonLib.git"
   },
   "frameworks": "arduino",
-  "platforms": 
+  "platforms":
   [
     "atmelavr",
     "atmelsam"
   ]
+  "version": 1.0,
 }

--- a/library.json
+++ b/library.json
@@ -13,5 +13,5 @@
     "atmelavr",
     "atmelsam"
   ]
-  "version": 1.0,
+  "version": 1.0
 }


### PR DESCRIPTION
Hi, I've added two lines of code to the readVcc function for 644/1284 support. Tested on a 1284P MCU, non tested on 644 but it should work.

  #elif defined(__AVR_ATmega644__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__)
  ADMUX = _BV(REFS0) | _BV(MUX4) | _BV(MUX3) | _BV(MUX2) | _BV(MUX1);

Ciao!
