### PR TITLE
Remove duplicate #includes

### DIFF
--- a/EmonLib.cpp
+++ b/EmonLib.cpp
@@ -9,14 +9,7 @@
 
 // Proboscide99 10/08/2016 - Added ADMUX settings for ATmega1284 e 1284P (644 / 644P also, but not tested) in readVcc function
 
-//#include "WProgram.h" un-comment for use on older versions of Arduino IDE
 #include "EmonLib.h"
-
-#if defined(ARDUINO) && ARDUINO >= 100
-#include "Arduino.h"
-#else
-#include "WProgram.h"
-#endif
 
 
 //--------------------------------------------------------------------------------------


### PR DESCRIPTION
Arduino.h / WProgram.h already `#include`d identically by EmonLib.h