### PR TITLE
Support for ATmega328PB

### DIFF
--- a/EmonLib.cpp
+++ b/EmonLib.cpp
@@ -231,7 +231,7 @@ long EnergyMonitor::readVcc() {
 
   //not used on emonTx V3 - as Vcc is always 3.3V - eliminates bandgap error and need for calibration http://harizanov.com/2013/09/thoughts-on-avr-adc-accuracy/
 
-  #if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328__) || defined (__AVR_ATmega328P__)
+  #if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328__) || defined (__AVR_ATmega328P__) || defined (__AVR_ATmega328PB__)
   ADMUX = _BV(REFS0) | _BV(MUX3) | _BV(MUX2) | _BV(MUX1);
   #elif defined(__AVR_ATmega644__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__)
   ADMUX = _BV(REFS0) | _BV(MUX4) | _BV(MUX3) | _BV(MUX2) | _BV(MUX1);


### PR DESCRIPTION
Added (trivial) support for the ATmega328PB revision of the common ATmega328P chip.

It has several small internal changes not relevant to the library, but the voltage reference works the same as the previous version of the chip, according to the official application note that can be found [here](http://ww1.microchip.com/downloads/en/AppNotes/00002447A.pdf).