### PR TITLE
Support for Arduino Uno R4

### DIFF
--- a/EmonLib.cpp
+++ b/EmonLib.cpp
@@ -106,9 +106,9 @@ void EnergyMonitor::calcVI(unsigned int crossings, unsigned int timeout)
     // B) Apply digital low pass filters to extract the 2.5 V or 1.65 V dc offset,
     //     then subtract this - signal is now centred on 0 counts.
     //-----------------------------------------------------------------------------
-    offsetV = offsetV + ((sampleV-offsetV)/1024);
+    offsetV = offsetV + ((sampleV-offsetV)/ADC_COUNTS);
     filteredV = sampleV - offsetV;
-    offsetI = offsetI + ((sampleI-offsetI)/1024);
+    offsetI = offsetI + ((sampleI-offsetI)/ADC_COUNTS);
     filteredI = sampleI - offsetI;
 
     //-----------------------------------------------------------------------------
@@ -188,7 +188,7 @@ double EnergyMonitor::calcIrms(unsigned int Number_of_Samples)
 
     // Digital low pass filter extracts the 2.5 V or 1.65 V dc offset,
     //  then subtract this - signal is now centered on 0 counts.
-    offsetI = (offsetI + (sampleI-offsetI)/1024);
+    offsetI = (offsetI + (sampleI-offsetI)/ADC_COUNTS);
     filteredI = sampleI - offsetI;
 
     // Root-mean-square method current
@@ -254,6 +254,8 @@ long EnergyMonitor::readVcc() {
   result |= ADCH<<8;
   result = READVCC_CALIBRATION_CONST / result;  //1100mV*1024 ADC steps http://openenergymonitor.org/emon/node/1186
   return result;
+  #elif defined(ARDUINO_ARCH_RENESAS)
+  return (long) (analogReference() * 1000.0);
   #elif defined(__arm__)
   return (3300);                                  //Arduino Due
   #else

--- a/EmonLib.h
+++ b/EmonLib.h
@@ -29,11 +29,13 @@
 #define READVCC_CALIBRATION_CONST 1126400L
 #endif
 
-// to enable 12-bit ADC resolution on Arduino Due,
+// for boards with ADC resolution higher than 10 bits (Arduino Due, Arduino Uno R4),
 // include the following line in main sketch inside setup() function:
 //  analogReadResolution(ADC_BITS);
 // otherwise will default to 10 bits, as in regular Arduino-based boards.
-#if defined(__arm__)
+#if defined(ARDUINO_ARCH_RENESAS)
+#define ADC_BITS    14
+#elif defined(__arm__)
 #define ADC_BITS    12
 #else
 #define ADC_BITS    10


### PR DESCRIPTION
Supports the 14-bit precision of the R4 ADC and the reference voltage readings for `EnergyMonitor::readVcc()`.